### PR TITLE
Fixed a NameError (uninitialized constant) problem

### DIFF
--- a/lib/newrelic-grape/instrument.rb
+++ b/lib/newrelic-grape/instrument.rb
@@ -1,3 +1,5 @@
+require 'new_relic/agent/instrumentation/controller_instrumentation'
+
 module NewRelic
   module Agent
     module Instrumentation


### PR DESCRIPTION
When I use this gem with Rails 3.2.13 and run `rails console`, this gem raises the following error.
- ruby/2.0.0/gems/newrelic-grape-1.2.0/lib/newrelic-grape/instrument.rb:5:in `class:Grape': uninitialized constant NewRelic::Agent::Instrumentation::Grape::ControllerInstrumentation (NameError)
