### PR TITLE
Fixed newrelic_ignore problem

### DIFF
--- a/lib/newrelic-grape/instrument.rb
+++ b/lib/newrelic-grape/instrument.rb
@@ -1,3 +1,4 @@
+require 'newrelic_rpm'
 require 'new_relic/agent/instrumentation/controller_instrumentation'
 
 module NewRelic


### PR DESCRIPTION
When I use this gem with RailsAdmin gem, I get the following error.

```
undefined local variable or method `newrelic_ignore' for RailsAdmin::ApplicationController:Class (NameError)
```

Though this problem occurs because RailsAdmin uses `newrelic_ignore` method internally, I think that the same problems will occur when it is used in other places.

So, I suppose this problem should be fixed.
