### PR TITLE
Added params to NewRelic call

### DIFF
--- a/lib/newrelic-grape/instrument.rb
+++ b/lib/newrelic-grape/instrument.rb
@@ -13,7 +13,8 @@ module NewRelic
           trace_options = {
             :category => :rack,
             :path => "#{request_method} #{request_path}",
-            :request => @newrelic_request
+            :request => @newrelic_request,
+            :params => @newrelic_request.params
           }
           perform_action_with_newrelic_trace(trace_options) do
             @app_response = @app.call(@env)


### PR DESCRIPTION
I needed support for showing request parameters in NewRelic for our API which is built with grape, so I've built it in.

![params](https://f.cloud.github.com/assets/523019/488174/97ffb354-b977-11e2-897b-60b24823b2fa.png)

I hope you can add this to your gem and release it, so we can continue using this gem.
