### PR TITLE
Don't require newrelic_rpm to avoid autostart

### DIFF
--- a/lib/newrelic-grape/instrument.rb
+++ b/lib/newrelic-grape/instrument.rb
@@ -1,4 +1,3 @@
-require 'newrelic_rpm'
 require 'new_relic/agent/instrumentation/controller_instrumentation'
 
 module NewRelic


### PR DESCRIPTION
Hi,

it seems that latest versions of `newrelic_rpm` tries to autostart the agent automatically when requiring `newrelic_rpm`, hence before the grape instrumentation is registered!

Removing the requiring of `newrelic_rpm` solves this issue.
