### PR TITLE
Add version to request path

### DIFF
--- a/lib/newrelic-grape/instrument.rb
+++ b/lib/newrelic-grape/instrument.rb
@@ -20,14 +20,21 @@ module NewRelic
           end
         end
 
+        def route
+          env['api.endpoint'].routes.first
+        end
+
         def request_path
-          env['api.endpoint'].routes.first.route_path[1..-1].gsub("/", "-").sub(/\(\.:format\)\z/, "")
+          path = route.route_path[1..-1].gsub('/', '-')
+          path.sub!(/\(\.:format\)\z/, '')
+          route.route_version && path.sub!(':version', route.route_version)
+
+          path
         end
 
         def request_method
           @newrelic_request.request_method
         end
-
       end
     end
   end


### PR DESCRIPTION
Changes:
- Add :version substitution to request path
- rewrite spec from should to expect
- add additional contexts: api with and without version
- add additional checks for parameters in
  perform_action_with_newrelic_trace
