### PR TITLE
Fix "uninitialized constant NewRelic::MetricSpec (NameError)" for newrelic_rpm 3.8.1.221

### DIFF
--- a/lib/newrelic-grape/instrument.rb
+++ b/lib/newrelic-grape/instrument.rb
@@ -1,3 +1,4 @@
+require 'new_relic/agent/instrumentation'
 require 'new_relic/agent/instrumentation/controller_instrumentation'
 
 module NewRelic


### PR DESCRIPTION
Minimum replicate code: https://gist.github.com/kyanny/ea06c6eb76500c3ed15a

At newrelic_rpm 3.8.0.218, dependency is resolved like this:

```
- newrelic-grape/instrument
  - new_relic/agent/instrumentation/controller_instrumentation
    - new_relic/agent/transaction
      - new_relic/agent/transaction/pop
        - new_relic/agent/instrumentation
          - new_relic/agent
            - new_relic/metric_spec
```

But at newrelic_rpm 3.8.1.221, new_relic/agent/transaction/pop was deleted ([e709be6](https://github.com/newrelic/rpm/commit/e709be61edd2abb63f524c49dab13abc346005fd)), so dependency was broken.
Therefore newrelic-grape no longer loads `NewRelic::MetricSpec` and raises exception at application launch timing.

To solve this dependency problem, require new_relic/agent/instrumentation clearly.
