### PR TITLE
Increase log level of installation announcement to INFO

### DIFF
--- a/lib/newrelic-grape/instrument.rb
+++ b/lib/newrelic-grape/instrument.rb
@@ -50,7 +50,7 @@ DependencyDetection.defer do
   end
 
   executes do
-    NewRelic::Agent.logger.debug 'Installing Grape instrumentation'
+    NewRelic::Agent.logger.info 'Installing Grape instrumentation'
   end
 
   executes do


### PR DESCRIPTION
Given these messages are all at the INFO log level:

```
Installing Dalli Memcache instrumentation
Installing deferred Rack instrumentation
Installing Net instrumentation
Installing Rack::Builder middleware instrumentation
Installing ActiveRecord 4 instrumentation
```

It seems appropriate that this one is, too. This should help users confirm that the instrumentation is active in production environments.