### PR TITLE
Compatibility with grape v0.17 and up.

### DIFF
--- a/lib/newrelic-grape/instrument.rb
+++ b/lib/newrelic-grape/instrument.rb
@@ -79,9 +79,9 @@ DependencyDetection.defer do
 
           alias_method :_build_stack, :build_stack
 
-          def build_stack
+          def build_stack(*args)
             use ::NewRelic::Agent::Instrumentation::Grape
-            _build_stack
+            _build_stack(*args)
           end
         end
       end


### PR DESCRIPTION
The arity of `Grape::Endpoint.build_stack` [changes in v0.17.0](https://github.com/ruby-grape/grape/commit/7805dd0076f2b21e2f861665c2774ef1e112190d#diff-8e15cddb80f42ca7d43872846d80ecbeR247). This PR passes through arguments as received, so it should continue to work correctly for grape v0.14.0 as well.

Let me know if you'd like any changes made, I'm open to suggestions for a better name than `args`. 😄